### PR TITLE
Some changes to make build work on FreeBSD and MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 SET(CMAKE_C_FLAGS "-Wall -O2 -g ${CMAKE_CXX_FLAGS}")
 
+SET(getopt_SOURCES )
+include(CheckSymbolExists)
+check_symbol_exists(getopt unistd.h HAVE_GETOPT)
+if(NOT HAVE_GETOPT)
+   list(APPEND getopt_SOURCES lib/getopt.c)
+endif()
+
+configure_file(lib/config.h.in lib/config.h)
 
 INCLUDE_DIRECTORIES(src lib test include)
 
@@ -20,7 +28,7 @@ SET(ITHITOOLS_LIBRARY_FILES
    lib/pcap_reader.cpp
    lib/UsefulTransaction.cpp
    lib/NamePattern.cpp
-   lib/getopt.c
+   ${getopt_SOURCES}
    lib/DnscapPlugIn.cpp
    lib/M7Getter.cpp
    lib/CsvHelper.cpp
@@ -62,7 +70,7 @@ ADD_EXECUTABLE(ithitools
    lib/UsefulTransaction.cpp
    lib/NamePattern.cpp
    lib/M7Getter.cpp
-   lib/getopt.c
+   ${getopt_SOURCES}
    lib/CsvHelper.cpp
    lib/M1Data.cpp
    lib/M2Data.cpp

--- a/lib/DnscapPlugIn.cpp
+++ b/lib/DnscapPlugIn.cpp
@@ -35,10 +35,15 @@
  * This code provides an implementation of the required functions, which
  * will link to a static set of C++ objects for doing the capture.
  */
-
+#include "config.h"
 #include "DnsStats.h"
+#ifndef HAVE_GETOPT
 #include "getopt.h"
+#endif
 #include "dnscap_common.h"
+#ifndef _WINDOWS
+#include <sys/socket.h>
+#endif
 
 /*
  * Common static variables. They have to be initialized and deleted as captures 

--- a/lib/DnscapPlugIn.cpp
+++ b/lib/DnscapPlugIn.cpp
@@ -37,7 +37,9 @@
  */
 #include "config.h"
 #include "DnsStats.h"
-#ifndef HAVE_GETOPT
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
 #endif
 #include "dnscap_common.h"

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine HAVE_GETOPT

--- a/src/ithitest.cpp
+++ b/src/ithitest.cpp
@@ -26,7 +26,9 @@
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
-#ifndef HAVE_GETOPT
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
 #endif
 #include "CaptureSummary.h"

--- a/src/ithitest.cpp
+++ b/src/ithitest.cpp
@@ -21,12 +21,14 @@
 
 // ithitest.cpp : Defines the entry point for the test application.
 //
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
+#ifndef HAVE_GETOPT
 #include "getopt.h"
+#endif
 #include "CaptureSummary.h"
 #include "ithimetrics.h"
 

--- a/src/ithitools.cpp
+++ b/src/ithitools.cpp
@@ -28,10 +28,13 @@
 #include "stdio.h"
 #endif
 
+#include "config.h"
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
+#ifndef HAVE_GETOPT
 #include "getopt.h"
+#endif
 #include "CaptureSummary.h"
 #include "ithimetrics.h"
 #include "ithipublisher.h"

--- a/src/ithitools.cpp
+++ b/src/ithitools.cpp
@@ -32,7 +32,9 @@
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
-#ifndef HAVE_GETOPT
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
 #endif
 #include "CaptureSummary.h"

--- a/test/PluginTest.cpp
+++ b/test/PluginTest.cpp
@@ -25,6 +25,9 @@
 #include "pcap_reader.h"
 #include "CaptureSummary.h"
 #include "PluginTest.h"
+#ifndef _WINDOWS
+#include <sys/socket.h>
+#endif
 
 #ifdef _WINDOWS
 #ifndef _WINDOWS64


### PR DESCRIPTION
Please review carefully.
cmake will create a config.h in the lib directory (with these changes) to indicate whether or not the `getopt()` function was available in `unistd.h`.
The include of `unistd.h` was needed on MacOS
The include of `sys/socket.h` was necessary on FreeBSD (at least) to be able to use `AF_INET` and `AF_INET6`