### PR TITLE
Continuous Integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: cpp
+os:
+  - linux
+  - osx
 compiler:
   - gcc
   - clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+sudo: false
+language: cpp
+compiler:
+  - gcc
+  - clang
+script:
+  - CXXFLAGS="-Wall -Wextra -Wpedantic" CFLAGS="-Wall -Wextra -Wpedantic" cmake .
+  - make
+  - ./ithitest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,14 @@ SET(CMAKE_CXX_STANDARD 11)
 SET(CMAKE_C_FLAGS "-std=c99 -Wall -O2 -g ${CC_WARNING_FLAGS} ${CMAKE_C_FLAGS}")
 SET(CMAKE_C_FLAGS "-Wall -O2 -g ${CMAKE_CXX_FLAGS}")
 
+SET(getopt_SOURCES )
+include(CheckSymbolExists)
+check_symbol_exists(getopt unistd.h HAVE_GETOPT)
+if(NOT HAVE_GETOPT)
+   list(APPEND getopt_SOURCES lib/getopt.c)
+endif()
+
+configure_file(lib/config.h.in lib/config.h)
 
 INCLUDE_DIRECTORIES(src lib test include)
 
@@ -20,7 +28,7 @@ SET(ITHITOOLS_LIBRARY_FILES
    lib/pcap_reader.cpp
    lib/UsefulTransaction.cpp
    lib/NamePattern.cpp
-   lib/getopt.c
+   ${getopt_SOURCES}
    lib/DnscapPlugIn.cpp
    lib/M7Getter.cpp
    lib/CsvHelper.cpp
@@ -62,7 +70,7 @@ ADD_EXECUTABLE(ithitools
    lib/UsefulTransaction.cpp
    lib/NamePattern.cpp
    lib/M7Getter.cpp
-   lib/getopt.c
+   ${getopt_SOURCES}
    lib/CsvHelper.cpp
    lib/M1Data.cpp
    lib/M2Data.cpp

--- a/lib/DnscapPlugIn.cpp
+++ b/lib/DnscapPlugIn.cpp
@@ -35,10 +35,17 @@
  * This code provides an implementation of the required functions, which
  * will link to a static set of C++ objects for doing the capture.
  */
-
+#include "config.h"
 #include "DnsStats.h"
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
+#endif
 #include "dnscap_common.h"
+#ifndef _WINDOWS
+#include <sys/socket.h>
+#endif
 
 /*
  * Common static variables. They have to be initialized and deleted as captures 

--- a/lib/config.h.in
+++ b/lib/config.h.in
@@ -1,0 +1,1 @@
+#cmakedefine HAVE_GETOPT

--- a/src/ithitest.cpp
+++ b/src/ithitest.cpp
@@ -21,12 +21,16 @@
 
 // ithitest.cpp : Defines the entry point for the test application.
 //
-
+#include "config.h"
 #include <stdio.h>
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
+#endif
 #include "CaptureSummary.h"
 #include "ithimetrics.h"
 

--- a/src/ithitools.cpp
+++ b/src/ithitools.cpp
@@ -28,10 +28,15 @@
 #include "stdio.h"
 #endif
 
+#include "config.h"
 #include <stdlib.h>
 #include "pcap_reader.h"
 #include "DnsStats.h"
+#ifdef HAVE_GETOPT
+#include <unistd.h>
+#else
 #include "getopt.h"
+#endif
 #include "CaptureSummary.h"
 #include "ithimetrics.h"
 #include "ithipublisher.h"

--- a/test/PluginTest.cpp
+++ b/test/PluginTest.cpp
@@ -25,6 +25,9 @@
 #include "pcap_reader.h"
 #include "CaptureSummary.h"
 #include "PluginTest.h"
+#ifndef _WINDOWS
+#include <sys/socket.h>
+#endif
 
 #ifdef _WINDOWS
 #ifndef _WINDOWS64


### PR DESCRIPTION
This will setup CI with Travis.
Since this `.travis.yml` also tests on MacOS, it has changes with PR #58 already included.
If you like CI with Travis, but do not want MacOS builds, you'll have to remove the `os:` section in the `.travis.yml` file.

You also have to enable Travis for the project by adding the Travis CI service here:
- https://github.com/private-octopus/ithitools/settings/installations

(and then enable the project with Travis )