### PR TITLE
Travis fail on tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ compiler:
   - gcc
   - clang
 script:
-  - CXXFLAGS="-Wall -Wextra -Wpedantic" CFLAGS="-Wall -Wextra -Wpedantic" cmake .
-  - make
+  - |
+      CXXFLAGS="-Wall -Wextra -Wpedantic -Werror" \
+        CFLAGS="-Wall -Wextra -Wpedantic -Werror" cmake .
+  - make -j 4
   - ./ithitest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: cpp
+addons:
+  apt:
+    packages:
+      - python
 os:
   - linux
   - osx
@@ -12,3 +16,4 @@ script:
         CFLAGS="-Wall -Wextra -Wpedantic -Werror" cmake .
   - make -j 4
   - ./ithitest
+  - python travis/check-dnsstats-tables.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,20 +5,21 @@ addons:
     packages:
       - python
       - valgrind
+      - clang-tools
 matrix:
   include:
     - os: linux
       compiler: gcc
-      env: VALGRIND=true
+      env: VALGRIND=true  ANALYSIS=true
     - os: linux
       compiler: clang
-      env: VALGRIND=true
+      env: VALGRIND=true  ANALYSIS=false
     - os: osx
       compiler: gcc
-      env: VALGRIND=false
+      env: VALGRIND=false ANALYSIS=false
     - os: osx
       compiler: clang
-      env: VALGRIND=false
+      env: VALGRIND=false ANALYSIS=false
 script:
   - |
       if $VALGRIND ; then
@@ -32,3 +33,14 @@ script:
   - ./ithitest
   - python travis/check-dnsstats-tables.py
   - if $VALGRIND ; then valgrind -v --error-exitcode=1 ./ithitest ; fi
+  - |
+      if $ANALYSIS ; then
+        mkdir analysis
+        ( cd analysis
+          echo "gitdir: ../.git" > .git
+          git reset --hard
+          scan-build cmake .
+          mkdir -p /tmp/ithipages/analysis
+          scan-build -o /tmp/ithipages/analysis --status-bugs -stats make
+        )
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ addons:
     packages:
       - python
       - valgrind
-      - clang-tools
 matrix:
   include:
     - os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,31 @@ addons:
   apt:
     packages:
       - python
-os:
-  - linux
-  - osx
-compiler:
-  - gcc
-  - clang
+      - valgrind
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      env: VALGRIND=true
+    - os: linux
+      compiler: clang
+      env: VALGRIND=true
+    - os: osx
+      compiler: gcc
+      env: VALGRIND=false
+    - os: osx
+      compiler: clang
+      env: VALGRIND=false
 script:
   - |
-      CXXFLAGS="-Wall -Wextra -Wpedantic -Werror" \
-        CFLAGS="-Wall -Wextra -Wpedantic -Werror" cmake .
+      if $VALGRIND ; then
+        CXXFLAGS="-Wall -Wextra -Wpedantic -Werror -g" \
+          CFLAGS="-Wall -Wextra -Wpedantic -Werror -g" cmake .
+      else
+        CXXFLAGS="-Wall -Wextra -Wpedantic -Werror" \
+          CFLAGS="-Wall -Wextra -Wpedantic -Werror" cmake .
+      fi
   - make -j 4
   - ./ithitest
   - python travis/check-dnsstats-tables.py
+  - if $VALGRIND ; then valgrind -v --error-exitcode=1 ./ithitest ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,6 @@ script:
           git reset --hard
           scan-build cmake .
           mkdir -p /tmp/ithipages/analysis
-          scan-build -o /tmp/ithipages/analysis --status-bugs -stats make
+          scan-build -o /tmp/ithipages/analysis --status-bugs make
         )
       fi

--- a/lib/M1Data.cpp
+++ b/lib/M1Data.cpp
@@ -110,7 +110,7 @@ bool M1Data::Load(char const * monthly_compliance_file_name)
                 line.nbBreaches = line.nbSuspensions;
                 line.nbSuspensions = line.nbTerminations;
                 line.nbTerminations = line.nbNonRenewals;
-                start = CsvHelper::read_number(&line.nbNonRenewals, start, buffer, sizeof(buffer));
+                CsvHelper::read_number(&line.nbNonRenewals, start, buffer, sizeof(buffer));
             }
             /* allocate data and add to vector */
             dataset.push_back(line);

--- a/lib/M2Data.cpp
+++ b/lib/M2Data.cpp
@@ -161,7 +161,7 @@ bool M2Data::Load(char const * monthly_csv_file_name)
         }
         start = CsvHelper::read_number(&line.NewlyAbusiveDomains, start, buffer, sizeof(buffer));
         start = CsvHelper::read_number(&line.LastMonthAbusiveDomains, start, buffer, sizeof(buffer));
-        start = CsvHelper::read_double(&line.LastMonthAbuseScore, start, buffer, sizeof(buffer));
+        CsvHelper::read_double(&line.LastMonthAbuseScore, start, buffer, sizeof(buffer));
 
         if (M2Type == Registrar && IsReservedRegistrarId(line.RegistrarId)) {
             /* Ignore data relative to parking registries */

--- a/lib/NamePattern.cpp
+++ b/lib/NamePattern.cpp
@@ -168,7 +168,7 @@ static double Tld_Dga_Eval_T_A(size_t len, uint8_t * val)
 
     for (size_t i = 0; i<len; i++)
     {
-        uint8_t t_group_index = transition_group[val[len] - 10];
+        uint8_t t_group_index = transition_group[val[i] - 10];
 
         if (previous_group < 2)
         {

--- a/lib/ithipublisher.cpp
+++ b/lib/ithipublisher.cpp
@@ -311,7 +311,7 @@ bool ithipublisher::LoadFileData(int file_index, char const * dir_met_name)
 
         start = CsvHelper::read_string(line->metric_name, sizeof(line->metric_name), start, buffer, sizeof(buffer));
         start = CsvHelper::read_string(line->key_value, sizeof(line->key_value), start, buffer, sizeof(buffer));
-        start = CsvHelper::read_double(&line->frequency, start, buffer, sizeof(buffer));
+        CsvHelper::read_double(&line->frequency, start, buffer, sizeof(buffer));
         line->year = file_list[file_index]->year;
         line->month = file_list[file_index]->month;
 
@@ -736,7 +736,7 @@ bool ithipublisher::PublishDataM3(FILE * F)
     }
     ret &= fprintf(F, ",\n") > 0;
 
-    ret = fprintf(F, "\"%s\" : ", met_data_name[1]) > 0;
+    ret &= fprintf(F, "\"%s\" : ", met_data_name[1]) > 0;
 
     if (ret)
     {

--- a/test/DnsPrefixTest.cpp
+++ b/test/DnsPrefixTest.cpp
@@ -154,13 +154,14 @@ bool DnsPrefixTest::DoOneTest(DnsStats * stats, char const * test_input, char co
     bool ret = true;
     char tiu[256];
     char teu[256];
+    char * ti;
     char * te;
     const char * tr;
 
-    (void)ToUpper(test_input, tiu, sizeof(tiu));
+    ti = ToUpper(test_input, tiu, sizeof(tiu));
     te = ToUpper(expected, teu, sizeof(teu));
 
-    tr = stats->GetZonePrefix(tiu);
+    tr = stats->GetZonePrefix(ti);
 
     if (tr == NULL) {
         if (te != NULL) {

--- a/test/LoadTest.cpp
+++ b/test/LoadTest.cpp
@@ -72,9 +72,8 @@ bool LoadTest::DoGoodTest()
 
 #ifdef _WINDOWS
         errno_t err = fopen_s(&F, good_file, "r");
-        bool ret = (err == 0 && F != NULL);
+        ret = (err == 0 && F != NULL);
 #else
-        bool ret;
         F = fopen(good_file, "r");
         ret = (F != NULL);
 #endif

--- a/test/MetricTest.cpp
+++ b/test/MetricTest.cpp
@@ -87,7 +87,7 @@ bool MetricTest::DoTest()
             ret = false;
             TEST_LOG("Could not set compliance file to %s\n", compliance_file);
         }
-        if (!met.SetRootZoneFileName(root_zone_file))
+	else if (!met.SetRootZoneFileName(root_zone_file))
         {
             ret = false;
             TEST_LOG("Could not set root zone file to %s\n", root_zone_file);

--- a/travis/check-dnsstats-tables.py
+++ b/travis/check-dnsstats-tables.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python
+
+import re, sys, csv
+try:
+	# For Python 3.0 and later
+	from urllib.request import urlopen
+except ImportError:
+	# Fall back to Python 2's urllib2
+	from urllib2 import urlopen
+
+if __name__ == '__main__':
+	fail = False
+	dnsstats = open('lib/DnsStats.cpp').read()
+	cpp_comments = re.compile("(/\*.*?\*/|//.*$)",re.DOTALL)
+
+	tlds_part         = re.sub(cpp_comments, "", dnsstats.split(
+	       'RegisteredTldName[] = {')[1].split('\n};')[0])
+	tlds              = set(eval('[' + tlds_part         + ']'))
+	rfc6761_tlds_part = re.sub(cpp_comments, "", dnsstats.split(
+	             'rfc6761_tld[] = {')[1].split('\n};')[0])
+	rfc6761_tlds      = set(eval('[' + rfc6761_tlds_part + ']'))
+	roots_part        = re.sub(cpp_comments, "", dnsstats.split(
+	    'DefaultRootAddresses[] = {')[1].split('\n};')[0])
+	roots             = set(eval('[' + roots_part        + ']'))
+	
+	iana_tlds_txt = urlopen(
+	    "https://data.iana.org/TLD/tlds-alpha-by-domain.txt").read()
+	iana_tlds = set(iana_tlds_txt.decode('utf-8').strip().split('\n')[1:])
+	if tlds != iana_tlds:
+		fail = True
+		if iana_tlds - tlds:
+			print( 'TLDs to add: "%s"'
+			     % '", "'.join(sorted(iana_tlds - tlds)))
+		if tlds - iana_tlds:
+			print( 'TLDs to remove: "%s"'
+			     % '", "'.join(sorted(tlds - iana_tlds)))
+
+	special_use_domain_names_txt = urlopen(
+	    "https://www.iana.org/assignments/special-use-domain-names/" + 
+	    "special-use-domain.csv").read().decode('utf-8')
+	special_use_domain_names = [ln[0] for ln in csv.reader(
+	    special_use_domain_names_txt.strip().upper().split('\n'))][1:]
+	iana_rfc6761_tlds = set(map(lambda x: x.split('.')[-2],
+	    special_use_domain_names)) - iana_tlds
+
+	if rfc6761_tlds != iana_rfc6761_tlds:
+		fail = True
+		if iana_rfc6761_tlds - rfc6761_tlds:
+			print( 'RFC6761 TLDs to add: "%s"' 
+			     % '", "'.join(
+				     sorted(iana_rfc6761_tlds - rfc6761_tlds)))
+		if rfc6761_tlds - iana_rfc6761_tlds:
+			print( 'RFC6761 TLDs to remove: "%s"'
+			     % '", "'.join(
+				     sorted(rfc6761_tlds - iana_rfc6761_tlds)))
+
+	root_hints = urlopen("https://www.internic.net/domain/named.root") \
+		     .read().decode('utf-8')
+	root_hints = set([ln.split()[-1] for ln in root_hints.split('\n')
+	                                 if ln[0].isalpha()])
+	if roots != root_hints:
+		if root_hints - roots:
+			fail = True
+			print( 'Root servers to add: "%s"'
+			     % '", "'.join(sorted(root_hints - roots)))
+		if roots - root_hints:
+			# Not a failure, because the old ones are kept
+			# working for a while
+			print( 'Root servers not in root.hints: "%s"' 
+			     % '", "'.join(sorted(roots - root_hints)))
+	if fail:
+		sys.exit(1)


### PR DESCRIPTION
This PR contains a few new tests.  Each test is in its own commit.
- travis will now fail when warnings are emitted (with -Wall -Wextra -Wpedantic options)
- The currentness of the builtin tables in DnsStats.cpp are tested
- The tests are run through valgrind (contains additional commit with fixes)
- Static analysis test with Clang (contains additional commit with fixes)

There is another branch that publishes reports from static analysis (and a few other reports).
The bugs found with static analysis (and fixed with this PR) have been reported there:
- <https://wtoorop.github.io/ithipages/analysis/2018-06-28-152702-4499-1/>